### PR TITLE
feat(@eurora/desktop): implement ability to initialize openai and ant…

### DIFF
--- a/apps/desktop/src/lib/bindings/bindings.ts
+++ b/apps/desktop/src/lib/bindings/bindings.ts
@@ -12,7 +12,7 @@ export type Query = { text: string; assets: string[] }
 
 export type ResponseChunk = { chunk: string }
 
-const ARGS_MAP = { '':'{"send_query":["channel","query"]}', 'auth':'{"get_login_token":[],"poll_for_login":[]}', 'context_chip':'{"get":[]}', 'monitor':'{"capture_monitor":["monitor_id"]}', 'third_party':'{"check_api_key_exists":[],"initialize_openai_client":[],"save_api_key":["api_key"],"switch_to_ollama":["base_url","model"],"switch_to_remote":["api_key","model"]}', 'window':'{"get_scale_factor":["height"],"resize_launcher_window":["height","scale_factor"]}' }
+const ARGS_MAP = { '':'{"send_query":["channel","query"]}', 'auth':'{"get_login_token":[],"poll_for_login":[]}', 'context_chip':'{"get":[]}', 'monitor':'{"capture_monitor":["monitor_id"]}', 'third_party':'{"check_api_key_exists":[],"initialize_openai_client":[],"save_api_key":["api_key"],"switch_to_ollama":["base_url","model"],"switch_to_remote":["provider","api_key","model"]}', 'window':'{"get_scale_factor":["height"],"resize_launcher_window":["height","scale_factor"]}' }
 export type Router = { "": {send_query: (channel: TAURI_CHANNEL<ResponseChunk>, query: Query) => Promise<string>},
 "auth": {get_login_token: () => Promise<LoginToken>, 
 poll_for_login: () => Promise<boolean>},
@@ -22,7 +22,7 @@ poll_for_login: () => Promise<boolean>},
 initialize_openai_client: () => Promise<boolean>, 
 save_api_key: (apiKey: string) => Promise<null>, 
 switch_to_ollama: (baseUrl: string, model: string) => Promise<null>, 
-switch_to_remote: (apiKey: string, model: string) => Promise<null>},
+switch_to_remote: (provider: string, apiKey: string, model: string) => Promise<null>},
 "window": {get_scale_factor: (height: number) => Promise<number>, 
 resize_launcher_window: (height: number, scaleFactor: number) => Promise<null>} };
 

--- a/apps/desktop/src/routes/(launcher)/launcher/+page.svelte
+++ b/apps/desktop/src/routes/(launcher)/launcher/+page.svelte
@@ -80,8 +80,8 @@
 	let statusCode = $state<string | null>(null);
 	let messagesContainer: HTMLElement;
 	const conversations = $state<Conversation[]>([]);
-	let hasApiKey = $state(false);
-	let isCheckingApiKey = $state(true);
+	let hasApiKey = $state(true);
+	let isCheckingApiKey = $state(false);
 	let currentConversationId = $state<string | null>(null);
 	const displayAssets = $state<DisplayAsset[]>([]);
 	let backgroundImage = $state<string | null>(null);
@@ -189,7 +189,7 @@
 		document.addEventListener('keydown', handleEscapeKey);
 
 		// Check if API key exists
-		checkApiKey();
+		// checkApiKey();
 
 		// Clean up event listener when component is unmounted
 		return () => {

--- a/crates/app/eur-tauri/src/procedures/third_party_procedures.rs
+++ b/crates/app/eur-tauri/src/procedures/third_party_procedures.rs
@@ -11,6 +11,7 @@ pub trait ThirdPartyApi {
     ) -> Result<(), String>;
     async fn switch_to_remote<R: Runtime>(
         app_handle: tauri::AppHandle<R>,
+        provider: String,
         api_key: String,
         model: String,
     ) -> Result<(), String>;
@@ -53,9 +54,6 @@ impl ThirdPartyApi for ThirdPartyApiImpl {
         self,
         app_handle: tauri::AppHandle<R>,
     ) -> Result<bool, String> {
-        let _api_key = secret::retrieve("OPENAI_API_KEY", secret::Namespace::Global)
-            .map_err(|e| format!("Failed to retrieve API key: {}", e))?;
-
         // Initialize the OpenAI client with the API key
         let promptkit_client = eur_prompt_kit::PromptKitService::default();
 
@@ -86,12 +84,16 @@ impl ThirdPartyApi for ThirdPartyApiImpl {
     async fn switch_to_remote<R: Runtime>(
         self,
         app_handle: tauri::AppHandle<R>,
+        provider: String,
         api_key: String,
         model: String,
     ) -> Result<(), String> {
         let mut promptkit_client = eur_prompt_kit::PromptKitService::default();
         promptkit_client
-            .switch_to_remote(eur_prompt_kit::RemoteConfig { api_key, model })
+            .switch_to_remote(
+                provider.into(),
+                eur_prompt_kit::RemoteConfig { api_key, model },
+            )
             .await?;
         let state: tauri::State<SharedPromptKitService> = app_handle.state();
         let mut guard = state.lock().await;

--- a/crates/common/eur-prompt-kit/src/lib.rs
+++ b/crates/common/eur-prompt-kit/src/lib.rs
@@ -30,6 +30,20 @@ impl From<EurLLMService> for LLMBackend {
     }
 }
 
+impl From<String> for EurLLMService {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "openai" => EurLLMService::OpenAI,
+            "anthropic" => EurLLMService::Anthropic,
+            "google" => EurLLMService::Google,
+            "eurora" => EurLLMService::Eurora,
+            "local" => EurLLMService::Local,
+            "ollama" => EurLLMService::Ollama,
+            _ => EurLLMService::OpenAI,
+        }
+    }
+}
+
 pub enum Role {
     System,
     User,

--- a/packages/ui/src/lib/custom-components/context-chip/context-chip.svelte
+++ b/packages/ui/src/lib/custom-components/context-chip/context-chip.svelte
@@ -71,6 +71,7 @@
 {/if}
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	/* Apply solid background for Linux desktop app */
 	:global(body.linux-app .context-chip) {
 		@apply bg-black/20 backdrop-blur-none blur-none;

--- a/packages/ui/src/lib/custom-components/message/message.svelte
+++ b/packages/ui/src/lib/custom-components/message/message.svelte
@@ -43,6 +43,7 @@
 </article>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	/* Apply solid background for Linux desktop app */
 	:global(body.linux-app .message) {
 		@apply bg-black/20 backdrop-blur-none blur-none;


### PR DESCRIPTION
…hropic as remote providers

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Connect" button for remote API providers, allowing users to initiate and track connection status directly in the onboarding flow.
  - Updated available model options for "openai" and "anthropic" providers with newer versions and labels.

- **Improvements**
  - Generalized support for multiple remote LLM providers, enabling dynamic backend selection for remote connections.
  - Enhanced chat streaming logic to support both OpenAI and Anthropic through a unified interface.

- **Style**
  - Enabled Tailwind CSS utility classes in context chip and message components for improved styling consistency.

- **Other Changes**
  - Removed "OpenRouter" as a selectable provider.
  - Adjusted initial API key state handling in the launcher, assuming presence by default and disabling runtime checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->