### PR TITLE
fix(@crates/eur-activity): make sure windows sends back .exe processes

### DIFF
--- a/crates/app/eur-activity/src/browser_activity.rs
+++ b/crates/app/eur-activity/src/browser_activity.rs
@@ -515,7 +515,6 @@ impl BrowserStrategy {
             "vivaldi.exe",
             "edge.exe",
             "msedge.exe",
-            "safari.exe",
         ];
         #[cfg(not(target_os = "windows"))]
         let processes = vec![


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of supported browser processes by using platform-specific process names for Windows and Unix-like systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->