### PR TITLE
feat(@crates/eur-tauri): add tray icon with skeleton quit button

### DIFF
--- a/crates/app/eur-tauri/Cargo.toml
+++ b/crates/app/eur-tauri/Cargo.toml
@@ -28,7 +28,7 @@ backtrace = { version = "0.3.75", optional = true }
 reqwest = { version = "0.12.19", features = ["json", "native-tls"] }
 serde.workspace = true
 serde_json = { version = "1.0", features = ["std", "arbitrary_precision"] }
-tauri = { version = "^2.5.1", features = ["unstable"] }
+tauri = { version = "^2.5.1", features = ["unstable", "tray-icon"] }
 tauri-plugin-dialog = "2.2.2"
 tauri-plugin-fs = "2.0.3"
 tauri-plugin-http = "2.4.4"

--- a/crates/app/eur-tauri/src/main.rs
+++ b/crates/app/eur-tauri/src/main.rs
@@ -36,9 +36,12 @@ use std::sync::{Arc, Mutex};
 use tauri::plugin::TauriPlugin;
 use tauri::{AppHandle, Emitter, Wry};
 use tauri::{Manager, generate_context};
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::TrayIconBuilder,
+};
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 use taurpc::Router;
-
 // Shared state to track if launcher is visible
 static LAUNCHER_VISIBLE: AtomicBool = AtomicBool::new(false);
 
@@ -117,6 +120,14 @@ fn main() {
                 .plugin(tauri_plugin_os::init())
                 .plugin(tauri_plugin_updater::Builder::new().build())
                 .setup(move |tauri_app| {
+                    let quit_i = MenuItem::with_id(tauri_app, "quit", "Quit", true, None::<&str>)?;
+                    let menu = Menu::with_items(tauri_app, &[&quit_i])?;
+                    TrayIconBuilder::new()
+                        .icon(tauri_app.default_window_icon().unwrap().clone())
+                        .menu(&menu)
+                        .show_menu_on_left_click(true)
+                        .build(tauri_app)
+                        .expect("Failed to create tray icon");
                     let _main_window =
                         create_window(tauri_app.handle(), "main", "onboarding".into())
                             // create_window(tauri_app.handle(), "main", "index.html".into())

--- a/crates/app/eur-tauri/src/main.rs
+++ b/crates/app/eur-tauri/src/main.rs
@@ -126,8 +126,14 @@ fn main() {
                         .icon(tauri_app.default_window_icon().unwrap().clone())
                         .menu(&menu)
                         .show_menu_on_left_click(true)
+                        .on_menu_event(move |app, event| {
+                            if event.id == "quit" {
+                                app.exit(0);
+                            }
+                        })
                         .build(tauri_app)
                         .expect("Failed to create tray icon");
+
                     let _main_window =
                         create_window(tauri_app.handle(), "main", "onboarding".into())
                             // create_window(tauri_app.handle(), "main", "index.html".into())

--- a/crates/backend/eur-auth-service/src/lib.rs
+++ b/crates/backend/eur-auth-service/src/lib.rs
@@ -293,7 +293,7 @@ impl AuthService {
         }
 
         // Validate and consume the OAuth state
-        let oauth_state = match self.db.get_oauth_state_by_state(state).await {
+        let _oauth_state = match self.db.get_oauth_state_by_state(state).await {
             Ok(oauth_state) => oauth_state,
             Err(_) => {
                 warn!("Invalid or expired OAuth state: {}", state);
@@ -312,7 +312,7 @@ impl AuthService {
         info!("OAuth state validated successfully for state: {}", state);
 
         // Extract PKCE verifier for token exchange
-        let pkce_verifier = oauth_state.pkce_verifier.clone();
+        // let pkce_verifier = oauth_state.pkce_verifier.clone();
 
         info!("Exchanging authorization code for access token");
 

--- a/crates/common/eur-auth-client/src/lib.rs
+++ b/crates/common/eur-auth-client/src/lib.rs
@@ -7,10 +7,7 @@ pub use eur_proto::proto_auth_service::{
     RegisterRequest, TokenResponse, login_request::Credential,
     proto_auth_service_client::ProtoAuthServiceClient,
 };
-use tonic::{
-    IntoRequest,
-    transport::{Channel, ClientTlsConfig},
-};
+use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::{error, info};
 
 /// gRPC client for authentication service


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a system tray icon with a context menu, including a "Quit" option, to the application. The tray icon uses the app's default window icon and displays the menu on left-click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->