### PR TITLE
feat(@crates/eur-prompt-service): add initial code to stream response…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,8 +2096,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "eur-auth-client",
  "eur-proto",
+ "eur-proto-client",
  "eur-secret",
  "jsonwebtoken",
  "serde",
@@ -2110,18 +2110,6 @@ dependencies = [
  "tonic",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "eur-auth-client"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "eur-proto",
- "tokio",
- "tonic",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2309,6 +2297,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "eur-proto",
+ "eur-proto-client",
  "eur-util",
  "futures",
  "image",
@@ -2316,6 +2305,7 @@ dependencies = [
  "openai-api-rs",
  "regex",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 
@@ -2351,6 +2341,18 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "eur-proto-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "eur-proto",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
 ]
 
 [[package]]
@@ -2403,7 +2405,6 @@ dependencies = [
  "dirs",
  "dotenv",
  "eur-activity",
- "eur-auth-client",
  "eur-client-grpc",
  "eur-client-questions",
  "eur-native-messaging",
@@ -2411,6 +2412,7 @@ dependencies = [
  "eur-personal-db",
  "eur-prompt-kit",
  "eur-proto",
+ "eur-proto-client",
  "eur-renderer",
  "eur-secret",
  "eur-timeline",
@@ -2489,8 +2491,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
- "eur-auth-client",
  "eur-proto",
+ "eur-proto-client",
  "eur-secret",
  "image",
  "rand 0.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "eur-proto",
+ "eur-secret",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "eur-auth",
  "eur-auth-service",
  "eur-ocr-service",
+ "eur-prompt-service",
  "eur-proto",
  "eur-remote-db",
  "futures",
@@ -2307,6 +2308,7 @@ name = "eur-prompt-kit"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "eur-proto",
  "eur-util",
  "futures",
  "image",
@@ -2315,6 +2317,27 @@ dependencies = [
  "regex",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "eur-prompt-service"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "dotenv",
+ "eur-auth",
+ "eur-ocr",
+ "eur-prompt-kit",
+ "eur-proto",
+ "futures",
+ "image",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ eur-auth-client = { path = "crates/common/eur-auth-client" }
 eur-prompt-kit = { path = "crates/common/eur-prompt-kit" }
 eur-util = { path = "crates/common/eur-util" }
 
+eur-prompt-service = { path = "crates/backend/eur-prompt-service" }
+eur-auth-service = { path = "crates/backend/eur-auth-service" }
+eur-ocr-service = { path = "crates/backend/eur-ocr-service" }
+eur-remote-db = { path = "crates/backend/eur-remote-db" }
+eur-monolith = { path = "crates/backend/eur-monolith" }
+
 [profile.release]
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better
 lto = true        # Enables link to optimizations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ eur-user = { path = "crates/app/eur-user" }
 eur-auth = { path = "crates/common/eur-auth" }
 eur-tauri = { path = "crates/app/eur-tauri" }
 eur-proto = { path = "crates/proto/eur-proto" }
-eur-auth-client = { path = "crates/common/eur-auth-client" }
+eur-proto-client = { path = "crates/common/eur-proto-client" }
 eur-prompt-kit = { path = "crates/common/eur-prompt-kit" }
 eur-util = { path = "crates/common/eur-util" }
 

--- a/crates/app/eur-tauri/Cargo.toml
+++ b/crates/app/eur-tauri/Cargo.toml
@@ -80,7 +80,7 @@ tauri-specta = { version = "2.0.0-rc.21", features = [
 ] }
 taurpc = { version = "0.5.1" }
 base64 = "0.22.1"
-eur-auth-client = { workspace = true }
+eur-proto-client = { workspace = true }
 dotenv = "0.15.0"
 eur-user = { workspace = true }
 

--- a/crates/app/eur-tauri/src/procedures/prompt_procedures.rs
+++ b/crates/app/eur-tauri/src/procedures/prompt_procedures.rs
@@ -63,13 +63,11 @@ impl PromptApi for PromptApiImpl {
         model: String,
     ) -> Result<(), String> {
         let mut promptkit_client = eur_prompt_kit::PromptKitService::default();
-        promptkit_client
-            .switch_to_remote(eur_prompt_kit::RemoteConfig {
-                provider: provider.into(),
-                api_key,
-                model,
-            })
-            .await?;
+        promptkit_client.switch_to_remote(eur_prompt_kit::RemoteConfig {
+            provider: provider.into(),
+            api_key,
+            model,
+        })?;
 
         TauRpcPromptApiEventTrigger::new(app_handle.clone())
             .prompt_service_change(Some(

--- a/crates/app/eur-user/Cargo.toml
+++ b/crates/app/eur-user/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = { version = "1.0", features = ["std", "arbitrary_precision"] }
 uuid = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
-eur-auth-client = { workspace = true }
+eur-proto-client = { workspace = true }
 base64 = { workspace = true }
 eur-proto = { workspace = true }
 tokio = { workspace = true }

--- a/crates/app/eur-user/src/auth.rs
+++ b/crates/app/eur-user/src/auth.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use eur_auth_client::AuthClient;
+use eur_proto_client::auth::AuthClient;
 use eur_secret::{Sensitive, secret};
 use rand::TryRngCore;
 use rand::rngs::OsRng;

--- a/crates/backend/eur-prompt-service/Cargo.toml
+++ b/crates/backend/eur-prompt-service/Cargo.toml
@@ -1,18 +1,13 @@
-
 [package]
-name = "eur-monolith"
+name = "eur-prompt-service"
 version = "0.0.1"
 edition = "2024"
 authors = ["Eurora <eurora@company.com>"]
 publish = false
 
 [dependencies]
-eur-proto = { workspace = true }
-eur-auth = { workspace = true }
-eur-ocr-service = { workspace = true }
-eur-auth-service = { workspace = true }
-eur-remote-db = { workspace = true }
-eur-prompt-service = { workspace = true }
+eur-proto = { path = "../../proto/eur-proto" }
+eur-auth = { path = "../../common/eur-auth" }
 anyhow = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
@@ -20,13 +15,10 @@ dotenv = "0.15"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
+tokio-stream = { workspace = true }
 image = { workspace = true }
+eur-ocr = { path = "../../common/eur-ocr" }
 futures = "0.3"
-sentry = { workspace = true }
-tonic-web = "0.13.1"
-tower = "0.5.2"
-tower-http = { version = "0.6.4", features = ["cors"] }
-tonic-health = "0.13.1"
-
+eur-prompt-kit = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/backend/eur-prompt-service/src/lib.rs
+++ b/crates/backend/eur-prompt-service/src/lib.rs
@@ -76,38 +76,18 @@ impl ProtoPromptService for PromptService {
 
         let messages = to_llm_message(request_inner.messages);
 
-        let (tx, rx) = mpsc::channel(128);
-        let mut stream = self
+        let stream = self
             .prompt_service
             .chat_stream(messages)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        // Spawn task without awaiting - this allows immediate return of the stream
-        tokio::spawn(async move {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(message) => {
-                        if let Err(e) = tx.send(Ok(SendPromptResponse { response: message })).await
-                        {
-                            warn!("Failed to send response through channel: {}", e);
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        warn!("LLM stream error: {}", e);
-                        // Send error as gRPC status instead of just breaking
-                        if let Err(send_err) = tx.send(Err(Status::internal(e.to_string()))).await {
-                            warn!("Failed to send error through channel: {}", send_err);
-                        }
-                        break;
-                    }
-                }
-            }
-            // Channel automatically closes when tx is dropped
+        // Direct stream mapping - much simpler than channel bridging
+        let output_stream = stream.map(|result| {
+            result
+                .map(|message| SendPromptResponse { response: message })
+                .map_err(|e| Status::internal(e.to_string()))
         });
-
-        let output_stream = ReceiverStream::new(rx);
 
         Ok(Response::new(
             Box::pin(output_stream) as Self::SendPromptStream

--- a/crates/backend/eur-prompt-service/src/lib.rs
+++ b/crates/backend/eur-prompt-service/src/lib.rs
@@ -1,0 +1,107 @@
+//! The Eurora Prompt service that provides gRPC endpoints for image transcription with JWT authentication.
+
+use anyhow::{Result, anyhow};
+use eur_auth::{Claims, JwtConfig, validate_access_token};
+use eur_prompt_kit::{LLMMessage, PromptKitService, Role};
+
+use eur_proto::proto_prompt_service::{
+    ProtoChatMessage, SendPromptRequest, SendPromptResponse,
+    proto_prompt_service_server::ProtoPromptService,
+};
+use std::{error::Error, io::ErrorKind, net::ToSocketAddrs, pin::Pin, time::Duration};
+use tokio::sync::mpsc;
+use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};
+use tonic::{Request, Response, Status, Streaming, transport::Server};
+use tracing::{info, warn};
+
+/// Extract and validate JWT token from request metadata
+pub fn authenticate_request<T>(request: &Request<T>, jwt_config: &JwtConfig) -> Result<Claims> {
+    // Get authorization header
+    let auth_header = request
+        .metadata()
+        .get("authorization")
+        .ok_or_else(|| anyhow!("Missing authorization header"))?;
+
+    // Convert to string
+    let auth_str = auth_header
+        .to_str()
+        .map_err(|_| anyhow!("Invalid authorization header format"))?;
+
+    // Extract Bearer token
+    if !auth_str.starts_with("Bearer ") {
+        return Err(anyhow!("Authorization header must start with 'Bearer '"));
+    }
+
+    let token = &auth_str[7..]; // Remove "Bearer " prefix
+
+    // Validate access token using shared function
+    validate_access_token(token, jwt_config)
+}
+
+#[derive(Debug, Default)]
+pub struct PromptService {
+    prompt_service: PromptKitService,
+    jwt_config: JwtConfig,
+}
+
+impl PromptService {
+    pub fn new(jwt_config: Option<JwtConfig>) -> Self {
+        Self {
+            prompt_service: PromptKitService::default(),
+            jwt_config: jwt_config.unwrap_or_default(),
+        }
+    }
+}
+
+type SendPromptResult<T> = Result<Response<T>, Status>;
+type SendPromptResponseStream =
+    Pin<Box<dyn Stream<Item = Result<SendPromptResponse, Status>> + Send>>;
+
+#[tonic::async_trait]
+impl ProtoPromptService for PromptService {
+    type SendPromptStream = SendPromptResponseStream;
+
+    async fn send_prompt(
+        &self,
+        request: Request<SendPromptRequest>,
+    ) -> SendPromptResult<Self::SendPromptStream> {
+        let request_inner = request.into_inner();
+        let messages = to_llm_message(request_inner.messages);
+
+        let mut stream = self
+            .prompt_service
+            .chat_stream(messages)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let (tx, rx) = mpsc::channel(128);
+
+        tokio::spawn(async move {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(message) => {
+                        tx.send(Ok(SendPromptResponse { response: message }))
+                            .await
+                            .unwrap();
+                    }
+                    Err(e) => {
+                        warn!("LLM error: {}", e);
+                        break;
+                    }
+                }
+            }
+        })
+        .await
+        .map_err(|e| Status::internal(e.to_string()))?;
+
+        let output_stream = ReceiverStream::new(rx);
+
+        Ok(Response::new(
+            Box::pin(output_stream) as Self::SendPromptStream
+        ))
+    }
+}
+
+fn to_llm_message(messages: Vec<ProtoChatMessage>) -> Vec<LLMMessage> {
+    messages.into_iter().map(|message| message.into()).collect()
+}

--- a/crates/backend/eur-prompt-service/src/lib.rs
+++ b/crates/backend/eur-prompt-service/src/lib.rs
@@ -7,10 +7,9 @@ use eur_proto::proto_prompt_service::{
     proto_prompt_service_server::ProtoPromptService,
 };
 use std::pin::Pin;
-use tokio::sync::mpsc;
-use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};
+use tokio_stream::{Stream, StreamExt};
 use tonic::{Request, Response, Status};
-use tracing::{info, warn};
+use tracing::info;
 
 /// Extract and validate JWT token from request metadata
 pub fn authenticate_request<T>(request: &Request<T>, jwt_config: &JwtConfig) -> Result<Claims> {
@@ -71,6 +70,8 @@ impl ProtoPromptService for PromptService {
         &self,
         request: Request<SendPromptRequest>,
     ) -> SendPromptResult<Self::SendPromptStream> {
+        authenticate_request(&request, &self.jwt_config)
+            .map_err(|e| Status::unauthenticated(e.to_string()))?;
         info!("Received send_prompt request");
         let request_inner = request.into_inner();
 

--- a/crates/backend/eur-prompt-service/src/lib.rs
+++ b/crates/backend/eur-prompt-service/src/lib.rs
@@ -1,17 +1,15 @@
-//! The Eurora Prompt service that provides gRPC endpoints for image transcription with JWT authentication.
-
 use anyhow::{Result, anyhow};
 use eur_auth::{Claims, JwtConfig, validate_access_token};
-use eur_prompt_kit::{LLMMessage, PromptKitService, Role};
+use eur_prompt_kit::{EurLLMService, LLMMessage, PromptKitService, RemoteConfig};
 
 use eur_proto::proto_prompt_service::{
     ProtoChatMessage, SendPromptRequest, SendPromptResponse,
     proto_prompt_service_server::ProtoPromptService,
 };
-use std::{error::Error, io::ErrorKind, net::ToSocketAddrs, pin::Pin, time::Duration};
+use std::pin::Pin;
 use tokio::sync::mpsc;
 use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};
-use tonic::{Request, Response, Status, Streaming, transport::Server};
+use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
 /// Extract and validate JWT token from request metadata
@@ -46,8 +44,16 @@ pub struct PromptService {
 
 impl PromptService {
     pub fn new(jwt_config: Option<JwtConfig>) -> Self {
+        let mut prompt_service = PromptKitService::default();
+        prompt_service
+            .switch_to_remote(RemoteConfig {
+                provider: EurLLMService::OpenAI,
+                api_key: std::env::var("OPENAI_API_KEY").unwrap_or_default(),
+                model: "gpt-4o-2024-11-20".to_string(),
+            })
+            .unwrap();
         Self {
-            prompt_service: PromptKitService::default(),
+            prompt_service,
             jwt_config: jwt_config.unwrap_or_default(),
         }
     }
@@ -65,16 +71,17 @@ impl ProtoPromptService for PromptService {
         &self,
         request: Request<SendPromptRequest>,
     ) -> SendPromptResult<Self::SendPromptStream> {
+        info!("Received send_prompt request");
         let request_inner = request.into_inner();
+
         let messages = to_llm_message(request_inner.messages);
 
+        let (tx, rx) = mpsc::channel(128);
         let mut stream = self
             .prompt_service
             .chat_stream(messages)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
-
-        let (tx, rx) = mpsc::channel(128);
 
         tokio::spawn(async move {
             while let Some(item) = stream.next().await {

--- a/crates/common/eur-auth/Cargo.toml
+++ b/crates/common/eur-auth/Cargo.toml
@@ -23,4 +23,4 @@ tauri-specta = { version = "2.0.0-rc.21", features = [
     "javascript",
     "typescript",
 ] }
-eur-auth-client = { workspace = true }
+eur-proto-client = { workspace = true }

--- a/crates/common/eur-auth/src/auth_manager.rs
+++ b/crates/common/eur-auth/src/auth_manager.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Duration, Utc};
-use eur_auth_client::AuthClient;
+use eur_proto_client::auth::AuthClient;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};

--- a/crates/common/eur-prompt-kit/Cargo.toml
+++ b/crates/common/eur-prompt-kit/Cargo.toml
@@ -11,7 +11,9 @@ llm = { git = "https://github.com/AndreRoelofs/llm.git", branch = "nightly", fea
 # llm = { version = "1.2.4", features = ["openai"] }
 openai-api-rs = { git = "https://github.com/AndreRoelofs/openai-api-rs.git", branch = "main" }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 eur-util = { workspace = true }
 regex = "1.9.6"
 tracing = { workspace = true }
 eur-proto = { workspace = true }
+eur-proto-client = { workspace = true }

--- a/crates/common/eur-prompt-kit/Cargo.toml
+++ b/crates/common/eur-prompt-kit/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { workspace = true }
 eur-util = { workspace = true }
 regex = "1.9.6"
 tracing = { workspace = true }
+eur-proto = { workspace = true }

--- a/crates/common/eur-prompt-kit/src/lib.rs
+++ b/crates/common/eur-prompt-kit/src/lib.rs
@@ -1,3 +1,4 @@
+use eur_proto::proto_prompt_service::ProtoChatMessage;
 use image::DynamicImage;
 use llm::{builder::LLMBackend, chat::ChatMessage};
 
@@ -114,6 +115,21 @@ impl From<ChatMessage> for LLMMessage {
             role: Role::User,
             content: MessageContent::Text(TextContent {
                 text: value.content.to_string(),
+            }),
+        }
+    }
+}
+
+impl From<ProtoChatMessage> for LLMMessage {
+    fn from(value: ProtoChatMessage) -> Self {
+        LLMMessage {
+            role: match value.role.as_str() {
+                "user" => Role::User,
+                "system" => Role::System,
+                _ => Role::User,
+            },
+            content: MessageContent::Text(TextContent {
+                text: value.content,
             }),
         }
     }

--- a/crates/common/eur-prompt-kit/src/lib.rs
+++ b/crates/common/eur-prompt-kit/src/lib.rs
@@ -4,7 +4,7 @@ use llm::{builder::LLMBackend, chat::ChatMessage};
 
 mod config;
 mod service;
-pub use config::{OllamaConfig, RemoteConfig};
+pub use config::{EuroraConfig, OllamaConfig, RemoteConfig};
 pub use service::PromptKitService;
 
 #[derive(Debug, Default, Copy, Clone)]

--- a/crates/common/eur-prompt-kit/src/lib.rs
+++ b/crates/common/eur-prompt-kit/src/lib.rs
@@ -134,3 +134,19 @@ impl From<ProtoChatMessage> for LLMMessage {
         }
     }
 }
+
+impl From<LLMMessage> for ProtoChatMessage {
+    fn from(value: LLMMessage) -> Self {
+        ProtoChatMessage {
+            role: match value.role {
+                Role::User => "user".to_string(),
+                Role::System => "system".to_string(),
+                _ => "user".to_string(),
+            },
+            content: match value.content {
+                MessageContent::Text(TextContent { text }) => text,
+                MessageContent::Image(ImageContent { text, image: _ }) => text.unwrap(),
+            },
+        }
+    }
+}

--- a/crates/common/eur-prompt-kit/src/service.rs
+++ b/crates/common/eur-prompt-kit/src/service.rs
@@ -106,7 +106,6 @@ Rules:
             Config::Ollama(config) => self._ollama_chat_stream(messages, config).await,
             Config::Remote(config) => self._remote_chat_stream(messages, config).await,
             Config::Eurora(config) => self._eurora_chat_stream(messages, config).await,
-            _ => Err(LLMError::Generic("Unsupported LLM backend".to_string())),
         }
     }
 

--- a/crates/common/eur-prompt-kit/src/service.rs
+++ b/crates/common/eur-prompt-kit/src/service.rs
@@ -1,4 +1,7 @@
-use crate::{LLMMessage, OllamaConfig, RemoteConfig, config::Config};
+use crate::{
+    LLMMessage, OllamaConfig, RemoteConfig,
+    config::{Config, EuroraConfig},
+};
 use anyhow::Result;
 use eur_util::redact_emails;
 use futures::Stream;
@@ -200,6 +203,12 @@ Rules:
         }
 
         self.config = Some(Config::Remote(config));
+
+        Ok(())
+    }
+
+    pub async fn switch_to_eurora(&mut self, config: EuroraConfig) -> Result<(), String> {
+        self.config = Some(Config::Eurora(config));
 
         Ok(())
     }

--- a/crates/common/eur-prompt-kit/src/service.rs
+++ b/crates/common/eur-prompt-kit/src/service.rs
@@ -116,7 +116,7 @@ Rules:
         _config: &EuroraConfig,
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
     {
-        let client = PromptClient::new(Some("http://localhost:50051".to_string()))
+        let client = PromptClient::new(None)
             .await
             .map_err(|e| LLMError::Generic(e.to_string()))?;
 

--- a/crates/common/eur-prompt-kit/src/service.rs
+++ b/crates/common/eur-prompt-kit/src/service.rs
@@ -10,9 +10,7 @@ use llm::{
     chat::ChatMessage,
     error::LLMError,
 };
-use tokio::sync::mpsc;
-use tokio_stream::{Stream, StreamExt, wrappers::ReceiverStream};
-use tracing::warn;
+use tokio_stream::{Stream, StreamExt};
 
 #[derive(Debug, Clone)]
 pub struct PromptKitService {

--- a/crates/common/eur-proto-client/Cargo.toml
+++ b/crates/common/eur-proto-client/Cargo.toml
@@ -14,3 +14,4 @@ tonic = { workspace = true, features = ["tls-native-roots", "channel"] }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-stream = { workspace = true }
+eur-secret = { workspace = true }

--- a/crates/common/eur-proto-client/Cargo.toml
+++ b/crates/common/eur-proto-client/Cargo.toml
@@ -1,17 +1,16 @@
+
 [package]
-name = "eur-auth-client"
+name = "eur-proto-client"
 version = "0.1.0"
 edition = "2024"
 authors = ["Eurora <eurora@company.com>"]
-description = "Eurora client authentication"
+description = "Eurora gRPC client"
 publish = false
 
 [dependencies]
 eur-proto = { workspace = true }
 anyhow = { workspace = true }
 tonic = { workspace = true, features = ["tls-native-roots", "channel"] }
-# rustls-native-certs = "0.8.1"
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
-
-tracing-subscriber = { workspace = true }
+tokio-stream = { workspace = true }

--- a/crates/common/eur-proto-client/src/clients/auth.rs
+++ b/crates/common/eur-proto-client/src/clients/auth.rs
@@ -24,7 +24,7 @@ impl AuthClient {
         Ok(Self { base_url })
     }
 
-    async fn try_init_client(&self) -> Result<Option<ProtoAuthServiceClient<Channel>>> {
+    async fn try_init_client(&self) -> Result<ProtoAuthServiceClient<Channel>> {
         let channel = get_secure_channel(self.base_url.clone())
             .await?
             .ok_or_else(|| anyhow!("Failed to initialize auth channel"))?;
@@ -32,7 +32,7 @@ impl AuthClient {
         let client = ProtoAuthServiceClient::new(channel);
 
         info!("Connected to auth service at {}", self.base_url);
-        Ok(Some(client))
+        Ok(client)
     }
 
     pub async fn login_by_password(
@@ -51,10 +51,7 @@ impl AuthClient {
 
     /// Login with email/username and password
     async fn login(&self, data: LoginRequest) -> Result<TokenResponse> {
-        let mut client = self
-            .try_init_client()
-            .await?
-            .ok_or_else(|| anyhow!("Failed to initialize client"))?;
+        let mut client = self.try_init_client().await?;
         let response = client.login(data).await.map_err(|e| {
             error!("Login failed: {}", e);
             anyhow!("Login failed: {}", e)
@@ -71,10 +68,7 @@ impl AuthClient {
         password: impl Into<String>,
         display_name: Option<String>,
     ) -> Result<TokenResponse> {
-        let mut client = self
-            .try_init_client()
-            .await?
-            .ok_or_else(|| anyhow!("Failed to initialize client"))?;
+        let mut client = self.try_init_client().await?;
         let response = client
             .register(RegisterRequest {
                 username: username.into(),
@@ -93,10 +87,7 @@ impl AuthClient {
 
     /// Refresh access token using refresh token
     pub async fn refresh_token(&self, refresh_token: impl Into<String>) -> Result<TokenResponse> {
-        let mut client = self
-            .try_init_client()
-            .await?
-            .ok_or_else(|| anyhow!("Failed to initialize client"))?;
+        let mut client = self.try_init_client().await?;
         let response = client
             .refresh_token(RefreshTokenRequest {
                 refresh_token: refresh_token.into(),
@@ -114,10 +105,7 @@ impl AuthClient {
         &self,
         login_token: impl Into<String>,
     ) -> Result<TokenResponse> {
-        let mut client = self
-            .try_init_client()
-            .await?
-            .ok_or_else(|| anyhow!("Failed to initialize client"))?;
+        let mut client = self.try_init_client().await?;
         let login_token = login_token.into();
         let response = client
             .login_by_login_token(LoginByLoginTokenRequest {
@@ -133,10 +121,7 @@ impl AuthClient {
     }
 
     pub async fn get_login_token(&self) -> Result<GetLoginTokenResponse> {
-        let mut client = self
-            .try_init_client()
-            .await?
-            .ok_or_else(|| anyhow!("Failed to initialize client"))?;
+        let mut client = self.try_init_client().await?;
         let response = client.get_login_token(()).await.map_err(|e| {
             error!("Get login token failed: {}", e);
             anyhow!("Get login token failed: {}", e)

--- a/crates/common/eur-proto-client/src/clients/mod.rs
+++ b/crates/common/eur-proto-client/src/clients/mod.rs
@@ -1,0 +1,2 @@
+pub mod auth;
+pub mod prompt;

--- a/crates/common/eur-proto-client/src/clients/prompt.rs
+++ b/crates/common/eur-proto-client/src/clients/prompt.rs
@@ -1,0 +1,49 @@
+use crate::get_secure_channel;
+use anyhow::{Result, anyhow};
+use eur_proto::proto_prompt_service::proto_prompt_service_client::ProtoPromptServiceClient;
+pub use eur_proto::proto_prompt_service::{
+    ProtoChatMessage, SendPromptRequest, SendPromptResponse,
+    proto_prompt_service_server::ProtoPromptService,
+};
+use tonic::{Streaming, transport::Channel};
+use tracing::info;
+
+#[derive(Clone)]
+pub struct PromptClient {
+    base_url: String,
+}
+
+impl PromptClient {
+    pub async fn new(base_url: Option<String>) -> Result<Self> {
+        let base_url = base_url.unwrap_or(
+            std::env::var("API_BASE_URL").unwrap_or("http://localhost:50051".to_string()),
+        );
+        Ok(Self { base_url })
+    }
+}
+
+impl PromptClient {
+    pub async fn try_init_client(&self) -> Result<Option<ProtoPromptServiceClient<Channel>>> {
+        let channel = get_secure_channel(self.base_url.clone())
+            .await?
+            .ok_or_else(|| anyhow!("Failed to initialize prompt channel"))?;
+
+        let client = ProtoPromptServiceClient::new(channel);
+
+        info!("Connected to prompt service at {}", self.base_url);
+        Ok(Some(client))
+    }
+
+    pub async fn send_prompt(
+        &self,
+        request: SendPromptRequest,
+    ) -> Result<Streaming<SendPromptResponse>> {
+        let mut client = self
+            .try_init_client()
+            .await?
+            .ok_or_else(|| anyhow!("Failed to initialize prompt client"))?;
+
+        let stream = client.send_prompt(request).await?.into_inner();
+        Ok(stream)
+    }
+}

--- a/crates/common/eur-proto-client/src/lib.rs
+++ b/crates/common/eur-proto-client/src/lib.rs
@@ -1,0 +1,16 @@
+mod clients;
+pub use clients::*;
+
+use anyhow::{Ok, Result, anyhow};
+use tonic::transport::{Channel, ClientTlsConfig};
+
+async fn get_secure_channel(base_url: String) -> Result<Option<Channel>> {
+    let tls = ClientTlsConfig::new().with_native_roots();
+    let channel = Channel::from_shared(base_url.clone())?
+        .tls_config(tls)?
+        .connect()
+        .await
+        .map_err(|e| anyhow!("Failed to connect to url: {}", e))?;
+
+    Ok(Some(channel))
+}

--- a/crates/proto/eur-proto/src/lib.rs
+++ b/crates/proto/eur-proto/src/lib.rs
@@ -36,6 +36,11 @@ pub mod generated {
         include!("gen/auth_service.rs");
         pub use super::*;
     }
+
+    pub mod proto_prompt_service {
+        include!("gen/prompt_service.rs");
+        pub use super::*;
+    }
 }
 
 // Convenience re-exports of the most commonly used types

--- a/proto/prompt_service.proto
+++ b/proto/prompt_service.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package prompt_service;
+
+service ProtoPromptService {
+    rpc SendPrompt (SendPromptRequest) returns (stream SendPromptResponse);
+}
+
+message ProtoChatMessage {
+    string role = 1;
+    string content = 2;
+}
+
+message SendPromptRequest {
+    repeated ProtoChatMessage messages = 1;
+}
+
+message SendPromptResponse {
+    string response = 1;
+}


### PR DESCRIPTION
…s from first party endpoint

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new gRPC Prompt Service supporting authenticated image transcription and chat message handling.
  * Added support for streaming prompt responses via a new gRPC endpoint.
  * Expanded the system with new backend modules for prompt, authentication, OCR, remote database, and monolithic orchestration.
  * Added a new prompt client for secure gRPC communication with the Prompt Service.

* **Improvements**
  * Enhanced chat message handling with robust conversion between protobuf and internal message formats.
  * Updated backend service integration for streamlined workspace dependency management.
  * Added ability to switch prompt service configuration to Eurora without validation checks.
  * Improved login flow to initialize and update prompt service client state upon successful authentication.
  * Refined prompt service switching logic to support synchronous and asynchronous modes.
  * Replaced authentication client dependency with a unified proto client for consistent gRPC communication.
  * Implemented secure channel establishment for gRPC clients using native TLS certificates.
  * Added timeout handling and filtering of empty chunks in streaming query responses.

* **Documentation**
  * Added new Protocol Buffers definitions for the Prompt Service API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->