### PR TITLE
feat(eur-monolith): migrate to openai for now

### DIFF
--- a/crates/backend/eur-prompt-service/src/lib.rs
+++ b/crates/backend/eur-prompt-service/src/lib.rs
@@ -58,7 +58,7 @@ impl PromptService {
             // "Llama Maverick",
             // "deepseek-ai/DeepSeek-V3-0324",
         );
-        config.base_url = Some("https://api.chat.nebul.io/v1".parse().unwrap());
+        // config.base_url = Some("https://api.chat.nebul.io/v1".parse().unwrap());
         Self {
             provider: OpenAIProvider::new(config).expect("Failed to create OpenAI provider"),
             jwt_config: jwt_config.unwrap_or_default(),


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Restored use of the default AI provider endpoint by removing a hardcoded override, improving connectivity and reducing request failures.
- Chores
  - Cleaned up prompt service initialization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->