### PR TITLE
fix(desktop/hotkey): issues with alt + key not being handled correctl…

### DIFF
--- a/apps/desktop/src/lib/components/Hotkey.svelte
+++ b/apps/desktop/src/lib/components/Hotkey.svelte
@@ -85,7 +85,19 @@
 
 		// Add the main key (if it's not a modifier)
 		if (!['Control', 'Meta', 'Alt', 'Shift'].includes(event.key)) {
-			const key = getKeyDisplay(event.key);
+			let key = event.key;
+
+			// Handle macOS Alt+key special character issue
+			if (
+				event.altKey &&
+				navigator.platform.toLowerCase().includes('mac') &&
+				event.code.startsWith('Key')
+			) {
+				// Extract the letter from the code (e.g., "KeyR" -> "r")
+				key = event.code.substring(3).toLowerCase();
+			}
+
+			const displayKey = getKeyDisplay(key);
 
 			// Only update if we have at least one modifier + main key, or special keys
 			if (
@@ -93,7 +105,7 @@
 				['Enter', 'Tab', 'Space'].includes(event.key) ||
 				/^F\d+$/.test(event.key)
 			) {
-				recordedHotkey = { modifiers, key };
+				recordedHotkey = { modifiers, key: displayKey };
 
 				// Clear existing timeout
 				if (recordingTimeout) {


### PR DESCRIPTION
…y on macos

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hotkey recording on macOS for Option (Alt) + letter combinations to display and store the intended character consistently.
  * Prevented incorrect symbols from appearing when recording shortcuts with Alt on macOS keyboards.
  * Ensured the final shortcut shown to users matches the key actually pressed.

* **Refactor**
  * Improved internal handling of main-key detection for macOS Alt+letter scenarios without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->