### PR TITLE
feat(desktop): add sidebar and footer settings

### DIFF
--- a/apps/desktop/src/lib/components/MainSidebar.svelte
+++ b/apps/desktop/src/lib/components/MainSidebar.svelte
@@ -4,9 +4,13 @@
 	import Inbox from '@lucide/svelte/icons/inbox';
 	import Search from '@lucide/svelte/icons/search';
 	import Settings from '@lucide/svelte/icons/settings';
+	import CircleUserRoundIcon from '@lucide/svelte/icons/circle-user-round';
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 	import * as Sidebar from '@eurora/ui/components/sidebar/index';
 	import EuroraLogo from '@eurora/ui/custom-icons/EuroraLogo.svelte';
+	import { Button } from '@eurora/ui/components/button/index';
 	import { useSidebar } from '@eurora/ui/components/sidebar/index';
+	import * as DropdownMenu from '@eurora/ui/components/dropdown-menu/index';
 	import { onMount } from 'svelte';
 
 	// type SidebarState = ReturnType<typeof
@@ -47,18 +51,21 @@
 	];
 </script>
 
-<Sidebar.Root collapsible="icon">
+<Sidebar.Root collapsible="icon" class="border-none">
 	<Sidebar.Header>
 		<div class="flex items-center justify-between">
-			<EuroraLogo class="size-7" />
+			<div class="flex items-center gap-2">
+				<EuroraLogo class="size-7" onclick={() => sidebarState?.setOpen(true)} />
+			</div>
+
 			{#if sidebarState?.open}
 				<Sidebar.Trigger />
 			{/if}
 		</div>
 	</Sidebar.Header>
 	<Sidebar.Content>
-		<Sidebar.Group>
-			<Sidebar.GroupLabel>Application</Sidebar.GroupLabel>
+		<!-- <Sidebar.Group>
+			<Sidebar.GroupLabel>Chats</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
 				<Sidebar.Menu>
 					{#each items as item (item.title)}
@@ -75,7 +82,35 @@
 					{/each}
 				</Sidebar.Menu>
 			</Sidebar.GroupContent>
-		</Sidebar.Group>
+		</Sidebar.Group> -->
 	</Sidebar.Content>
-	<Sidebar.Footer>Footer</Sidebar.Footer>
+	<Sidebar.Footer>
+		<Sidebar.Menu>
+			<Sidebar.MenuItem>
+				<DropdownMenu.Root>
+					<DropdownMenu.Trigger>
+						{#snippet child({ props })}
+							<Sidebar.MenuButton
+								{...props}
+								class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+							>
+								<CircleUserRoundIcon />
+								<span>Profile</span>
+								<ChevronUpIcon class="ml-auto" />
+							</Sidebar.MenuButton>
+						{/snippet}
+					</DropdownMenu.Trigger>
+					<DropdownMenu.Content side="top" class="w-(--bits-dropdown-menu-anchor-width)">
+						<DropdownMenu.Item>
+							{#snippet child({ props })}
+								<a {...props} href="/settings">
+									<span>Settings</span>
+								</a>
+							{/snippet}
+						</DropdownMenu.Item>
+					</DropdownMenu.Content>
+				</DropdownMenu.Root>
+			</Sidebar.MenuItem>
+		</Sidebar.Menu>
+	</Sidebar.Footer>
 </Sidebar.Root>

--- a/apps/desktop/src/lib/components/Menubar.svelte
+++ b/apps/desktop/src/lib/components/Menubar.svelte
@@ -42,13 +42,13 @@
 	}
 </script>
 
-<div class="flex items-center justify-between p-4 h-[70px]">
-	<div class="flex items-center gap-2">
+<div class="flex items-center justify-end p-4 h-[70px]">
+	<!-- <div class="flex items-center gap-2">
 		<a href="/onboarding" class="flex items-center gap-2">
 			<EuroraLogo class="size-12" />
 			Eurora Labs
 		</a>
-	</div>
+	</div> -->
 	<div class="flex items-center gap-2">
 		{#if service_name}
 			<DropdownMenu.Root>

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -14,9 +14,9 @@
 </script>
 
 <Menubar />
-<Sidebar.Provider>
+<Sidebar.Provider open={false}>
 	<MainSidebar />
-	<main class="flex flex-col h-full w-full">
+	<main class="flex flex-col h-[calc(100vh-70px)] w-full">
 		<div class="flex-1">{@render children?.()}</div>
 	</main>
 </Sidebar.Provider>


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->
https://github.com/eurora-labs/eurora/compare/feature/persistent-chats?expand=1
<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a profile dropdown in the sidebar footer with quick access to Settings.
- Style
  - Menubar content aligned to the right; visual spacing adjusted.
  - Sidebar border removed for a cleaner look.
  - Main content height adjusted to accommodate the header.
- Refactor
  - Sidebar now closed by default; logo click opens it.
  - Primary navigation in the sidebar temporarily hidden.
  - Onboarding/branding link removed from the menubar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->