### PR TITLE
feat(eur-tauri): add ability to automatically add new conversation cr…

### DIFF
--- a/apps/desktop/src/lib/bindings/bindings.ts
+++ b/apps/desktop/src/lib/bindings/bindings.ts
@@ -198,7 +198,7 @@ tool_call_id: string | null;
  */
 text: string | null }
 
-const ARGS_MAP = { 'auth':'{"get_login_token":[],"poll_for_login":[]}', 'chat':'{"current_conversation_changed":["conversation"],"send_query":["conversation","channel","query"],"switch_conversation":["conversation_id"]}', 'context_chip':'{"get":[]}', 'monitor':'{"capture_monitor":["monitor_id"]}', 'personal_db.conversation':'{"create":[],"get_messages":["conversation_id"],"list":["limit","offset"]}', 'personal_db.message':'{"get":["conversation_id","limit","offset"]}', 'prompt':'{"disconnect":[],"get_service_name":[],"prompt_service_change":["service_name"],"switch_to_ollama":["base_url","model"],"switch_to_remote":["provider","api_key","model"]}', 'settings':'{"get_all_settings":[],"get_general_settings":[],"get_hover_settings":[],"get_launcher_settings":[],"get_telemetry_settings":[],"set_general_settings":["general_settings"],"set_hover_settings":["hover_settings"],"set_launcher_settings":["launcher_settings"]}', 'system':'{"check_grpc_server_connection":["server_address"],"list_activities":[],"send_key_to_launcher":["key"]}', 'third_party':'{"check_api_key_exists":[],"save_api_key":["api_key"]}', 'user':'{"set_launcher_hotkey":["key","modifiers"]}', 'window':'{"get_scale_factor":["height"],"hide_hover_window":[],"open_launcher_window":[],"open_main_window":[],"resize_launcher_window":["height","scale_factor"],"show_hover_window":[]}' }
+const ARGS_MAP = { 'auth':'{"get_login_token":[],"poll_for_login":[]}', 'chat':'{"current_conversation_changed":["conversation"],"send_query":["conversation","channel","query"],"switch_conversation":["conversation_id"]}', 'context_chip':'{"get":[]}', 'monitor':'{"capture_monitor":["monitor_id"]}', 'personal_db.conversation':'{"create":[],"get_messages":["conversation_id"],"list":["limit","offset"],"new_conversation_added":["conversation"]}', 'personal_db.message':'{"get":["conversation_id","limit","offset"]}', 'prompt':'{"disconnect":[],"get_service_name":[],"prompt_service_change":["service_name"],"switch_to_ollama":["base_url","model"],"switch_to_remote":["provider","api_key","model"]}', 'settings':'{"get_all_settings":[],"get_general_settings":[],"get_hover_settings":[],"get_launcher_settings":[],"get_telemetry_settings":[],"set_general_settings":["general_settings"],"set_hover_settings":["hover_settings"],"set_launcher_settings":["launcher_settings"]}', 'system':'{"check_grpc_server_connection":["server_address"],"list_activities":[],"send_key_to_launcher":["key"]}', 'third_party':'{"check_api_key_exists":[],"save_api_key":["api_key"]}', 'user':'{"set_launcher_hotkey":["key","modifiers"]}', 'window':'{"get_scale_factor":["height"],"hide_hover_window":[],"open_launcher_window":[],"open_main_window":[],"resize_launcher_window":["height","scale_factor"],"show_hover_window":[]}' }
 export type Router = { "auth": {get_login_token: () => Promise<LoginToken>, 
 poll_for_login: () => Promise<boolean>},
 "chat": {current_conversation_changed: (conversation: Conversation) => Promise<void>, 
@@ -208,7 +208,8 @@ switch_conversation: (conversationId: string) => Promise<Conversation>},
 "monitor": {capture_monitor: (monitorId: string) => Promise<string>},
 "personal_db.conversation": {create: () => Promise<Conversation>, 
 get_messages: (conversationId: string) => Promise<Message[]>, 
-list: (limit: number, offset: number) => Promise<Conversation[]>},
+list: (limit: number, offset: number) => Promise<Conversation[]>, 
+new_conversation_added: (conversation: Conversation) => Promise<void>},
 "personal_db.message": {get: (conversationId: string, limit: number | null, offset: number | null) => Promise<Message[]>},
 "prompt": {disconnect: () => Promise<null>, 
 get_service_name: () => Promise<string>, 

--- a/apps/desktop/src/lib/components/MainSidebar.svelte
+++ b/apps/desktop/src/lib/components/MainSidebar.svelte
@@ -22,42 +22,19 @@
 		taurpc.personal_db.conversation.list(5, 0).then((res) => {
 			conversations = res;
 		});
+
+		taurpc.personal_db.conversation.new_conversation_added.on((conversation) => {
+			conversations = [conversation, ...conversations];
+		});
 	});
 
-	async function createChat() {}
+	async function createChat() {
+		await taurpc.personal_db.conversation.create();
+	}
 
 	async function switchConversation(id: string) {
 		await taurpc.chat.switch_conversation(id);
 	}
-
-	// Menu items.
-	// const items = [
-	// 	{
-	// 		title: 'Chat 1',
-	// 		url: '#',
-	// 		icon: House,
-	// 	},
-	// 	{
-	// 		title: 'Chat 2',
-	// 		url: '#',
-	// 		icon: Inbox,
-	// 	},
-	// 	{
-	// 		title: 'Chat 3',
-	// 		url: '#',
-	// 		icon: Calendar,
-	// 	},
-	// 	{
-	// 		title: 'Chat 4',
-	// 		url: '#',
-	// 		icon: Search,
-	// 	},
-	// 	{
-	// 		title: 'Chat 5',
-	// 		url: '#',
-	// 		icon: Settings,
-	// 	},
-	// ];
 </script>
 
 <Sidebar.Root collapsible="icon" class="border-none">
@@ -101,7 +78,7 @@
 									{#snippet child({ props })}
 										<a {...props}>
 											<!-- <item.icon /> -->
-											<span>{item.title}</span>
+											<span>{item.title ?? 'New Conversation'}</span>
 										</a>
 									{/snippet}
 								</Sidebar.MenuButton>

--- a/crates/app/eur-tauri/src/procedures/personal_db/conversation_procedures.rs
+++ b/crates/app/eur-tauri/src/procedures/personal_db/conversation_procedures.rs
@@ -8,6 +8,9 @@ use tauri::{Manager, Runtime};
 
 #[taurpc::procedures(path = "personal_db.conversation")]
 pub trait ConversationApi {
+    #[taurpc(event)]
+    async fn new_conversation_added(conversation: Conversation);
+
     async fn list<R: Runtime>(
         app_handle: tauri::AppHandle<R>,
         limit: u16,
@@ -54,6 +57,10 @@ impl ConversationApi for ConversationApiImpl {
         let current = app_handle.state::<SharedCurrentConversation>();
         let mut guard = current.lock().await;
         *guard = Some(conversation.clone());
+
+        TauRpcConversationApiEventTrigger::new(app_handle.clone())
+            .new_conversation_added(conversation.clone())
+            .map_err(|e| e.to_string())?;
 
         Ok(conversation)
     }


### PR DESCRIPTION
…eated via launcher

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - New conversations appear instantly in the sidebar without refresh.
  - Create chat from the sidebar now works reliably.
  - Conversations without a title show “New Conversation” by default.
  - Switch prompt services directly in-app: choose a local engine (e.g., Ollama with custom URL/model) or connect to a remote provider with your API key and model. The app updates when the service changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->