### PR TITLE
feat(eur-activity): add initial domain comparison

### DIFF
--- a/crates/app/eur-native-messaging/src/lib.rs
+++ b/crates/app/eur-native-messaging/src/lib.rs
@@ -6,6 +6,7 @@ pub mod server;
 pub mod types;
 pub mod utils;
 
+pub use server::IncomingMessage;
 pub use types::*;
 
 // Define the port as a constant to ensure consistency


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate activity reports when navigating within the same domain, reducing noise.

* **New Features**
  * Emits initial activity metadata immediately when tracking starts.

* **Enhancements**
  * Native messaging now tracks and echoes message IDs so responses match requests.
  * Extension background logging and message tracing improved for more reliable request/response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->