### PR TITLE
fix(chrome-extension): specifiying declarative network access

### DIFF
--- a/extensions/chromium/manifest.json
+++ b/extensions/chromium/manifest.json
@@ -33,13 +33,6 @@
 		"128": "icons/icon-128x128.png"
 	},
 	"incognito": "split",
-	"permissions": [
-		"nativeMessaging",
-		"tabs",
-		"storage",
-		"scripting",
-		"declarativeNetRequestWithHostAccess",
-		"webNavigation"
-	],
+	"permissions": ["nativeMessaging", "tabs", "storage", "scripting", "webNavigation"],
 	"host_permissions": ["<all_urls>"]
 }

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -50,7 +50,6 @@
 		"storage",
 		"scripting",
 		"activeTab",
-		"declarativeNetRequestWithHostAccess",
 		"webNavigation"
 	],
 	"browser_specific_settings": {


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Chromium extension permissions configuration through formatting cleanup.
  * Removed unused permission declaration from both Chromium and Firefox extension manifests to improve maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->