### PR TITLE
feat(agent-chain-core): make all properties of messages public

### DIFF
--- a/crates/common/agent-chain-core/src/lib.rs
+++ b/crates/common/agent-chain-core/src/lib.rs
@@ -128,7 +128,7 @@ pub use language_models::{
 // Re-export message types
 pub use messages::{
     AIMessage, AnyMessage, BaseMessage, ContentPart, HasId, HumanMessage, ImageDetail, ImageSource,
-    MessageContent, SystemMessage, ToolCall, ToolMessage,
+    MessageContent, SystemMessage, ToolCall, ToolMessage, convert_to_message, convert_to_messages,
 };
 
 // Re-export tool types

--- a/crates/common/agent-chain-core/src/messages.rs
+++ b/crates/common/agent-chain-core/src/messages.rs
@@ -136,7 +136,7 @@ pub use tool::{
 
 // Re-export from utils
 pub use utils::{
-    AnyMessage, MessageLikeRepresentation, convert_to_messages, filter_messages, get_buffer_string,
-    merge_message_runs, message_chunk_to_message, message_from_dict, message_to_dict,
-    messages_from_dict, messages_to_dict,
+    AnyMessage, MessageLikeRepresentation, convert_to_message, convert_to_messages,
+    filter_messages, get_buffer_string, merge_message_runs, message_chunk_to_message,
+    message_from_dict, message_to_dict, messages_from_dict, messages_to_dict,
 };

--- a/crates/common/agent-chain-core/src/messages/ai.rs
+++ b/crates/common/agent-chain-core/src/messages/ai.rs
@@ -180,6 +180,11 @@ impl AIMessage {
         }
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Create a new AI message with an explicit ID.
     ///
     /// Use this when deserializing or reconstructing messages where the ID must be preserved.

--- a/crates/common/agent-chain-core/src/messages/base.rs
+++ b/crates/common/agent-chain-core/src/messages/base.rs
@@ -109,6 +109,19 @@ impl BaseMessage {
         }
     }
 
+    /// Set id of the message
+    pub fn set_id(&mut self, id: String) {
+        match self {
+            BaseMessage::Human(m) => m.set_id(id),
+            BaseMessage::System(m) => m.set_id(id),
+            BaseMessage::AI(m) => m.set_id(id),
+            BaseMessage::Tool(m) => m.set_id(id),
+            BaseMessage::Chat(m) => m.set_id(id),
+            BaseMessage::Function(m) => m.set_id(id),
+            BaseMessage::Remove(m) => m.set_id(id),
+        }
+    }
+
     /// Get tool calls if this is an AI message.
     pub fn tool_calls(&self) -> &[ToolCall] {
         match self {

--- a/crates/common/agent-chain-core/src/messages/chat.rs
+++ b/crates/common/agent-chain-core/src/messages/chat.rs
@@ -51,6 +51,11 @@ impl ChatMessage {
         }
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Create a new chat message with an explicit ID.
     ///
     /// Use this when deserializing or reconstructing messages where the ID must be preserved.

--- a/crates/common/agent-chain-core/src/messages/function.rs
+++ b/crates/common/agent-chain-core/src/messages/function.rs
@@ -60,6 +60,11 @@ impl FunctionMessage {
         }
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Create a new function message with an explicit ID.
     ///
     /// Use this when deserializing or reconstructing messages where the ID must be preserved.

--- a/crates/common/agent-chain-core/src/messages/human.rs
+++ b/crates/common/agent-chain-core/src/messages/human.rs
@@ -156,6 +156,11 @@ impl HumanMessage {
         self.id.as_deref()
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Get the message name.
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()

--- a/crates/common/agent-chain-core/src/messages/modifier.rs
+++ b/crates/common/agent-chain-core/src/messages/modifier.rs
@@ -38,4 +38,9 @@ impl RemoveMessage {
     pub fn target_id(&self) -> &str {
         &self.id
     }
+
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
 }

--- a/crates/common/agent-chain-core/src/messages/system.rs
+++ b/crates/common/agent-chain-core/src/messages/system.rs
@@ -44,6 +44,11 @@ impl SystemMessage {
         }
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Create a new system message with an explicit ID.
     ///
     /// Use this when deserializing or reconstructing messages where the ID must be preserved.

--- a/crates/common/agent-chain-core/src/messages/tool.rs
+++ b/crates/common/agent-chain-core/src/messages/tool.rs
@@ -213,6 +213,11 @@ impl ToolMessage {
         }
     }
 
+    /// Set the message ID.
+    pub fn set_id(&mut self, id: String) {
+        self.id = Some(id);
+    }
+
     /// Create a new tool message with an explicit ID.
     ///
     /// Use this when deserializing or reconstructing messages where the ID must be preserved.


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
- Made message fields directly accessible to enable more flexible integrations and simpler data access without changing behavior.
- Added setters and explicit-ID constructors so IDs can be assigned or updated after creation.

## New Features
- Introduced a single-message conversion helper and updated public exports to simplify converting external payloads into internal message objects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->