### PR TITLE
fix(euro-activity): the application itself being selected in prod on …

### DIFF
--- a/crates/app/euro-activity/src/strategies/processes.rs
+++ b/crates/app/euro-activity/src/strategies/processes.rs
@@ -20,7 +20,12 @@ pub struct Eurora;
 
 impl ProcessFunctionality for Eurora {
     fn get_name(&self) -> &str {
-        os_pick("euro-tauri.exe", "euro-tauri", "euro-tauri")
+        // This process is used to ignore the application.
+        // So different names are used for debug and release builds.
+        match cfg!(debug_assertions) {
+            true => os_pick("euro-tauri.exe", "euro-tauri", "euro-tauri"),
+            false => os_pick("euro-tauri.exe", "euro-tauri", "Eurora"),
+        }
     }
 }
 


### PR DESCRIPTION
…Macos

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified application process identification based on build configuration. Debug builds are now identified as "euro-tauri" while release builds are identified as "Eurora". This ensures proper process tracking in system logs and monitoring utilities across development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->