### PR TITLE
feat(euro-tauri): rename the main binary name

### DIFF
--- a/crates/app/euro-activity/src/strategies/processes.rs
+++ b/crates/app/euro-activity/src/strategies/processes.rs
@@ -24,7 +24,7 @@ impl ProcessFunctionality for Eurora {
         // So different names are used for debug and release builds.
         match cfg!(debug_assertions) {
             true => os_pick("euro-tauri.exe", "euro-tauri", "euro-tauri"),
-            false => os_pick("euro-tauri.exe", "euro-tauri", "Eurora"),
+            false => os_pick("eurora.exe", "eurora", "Eurora"),
         }
     }
 }

--- a/crates/app/euro-tauri/tauri.conf.json
+++ b/crates/app/euro-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
 	"productName": "Eurora Dev",
 	"identifier": "com.eurora.app.dev",
+	"mainBinaryName": "eurora",
 	"build": {
 		"beforeDevCommand": "pnpm dev:internal-tauri",
 		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop build:launcher-window  -- --mode development",

--- a/crates/app/euro-tauri/tauri.conf.release.json
+++ b/crates/app/euro-tauri/tauri.conf.release.json
@@ -1,6 +1,7 @@
 {
 	"productName": "Eurora",
 	"identifier": "com.eurora.app",
+	"mainBinaryName": "eurora",
 	"build": {
 		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode production"
 	},


### PR DESCRIPTION
## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed application executable and binary identifier from "euro-tauri" to "eurora" across all release build configurations and system environments
  * Updated Tauri application configuration files to consistently reference the new primary binary name in both standard and release build profiles
  * Synchronized process identification and system recognition logic to align with the updated executable naming throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->