### PR TITLE
feat(be-payment-service): approved beta emails defaults to all if non…

### DIFF
--- a/crates/backend/be-payment-service/src/config.rs
+++ b/crates/backend/be-payment-service/src/config.rs
@@ -38,12 +38,15 @@ impl PaymentConfig {
             )
         })?;
 
-        let approved_beta_emails = std::env::var("APPROVED_BETA_EMAILS")
-            .unwrap_or_default()
-            .split(',')
-            .map(|s| s.trim().to_lowercase().to_string())
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
+        let approved_beta_emails = match std::env::var("APPROVED_BETA_EMAILS") {
+            Ok(emails) => emails
+                .split(',')
+                .map(|s| s.trim().to_lowercase().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>(),
+            // Allow all by default
+            Err(_) => vec!["*".to_string()],
+        };
 
         Ok(Self {
             stripe_secret_key,


### PR DESCRIPTION
…e is given

## 🧢 Changes

## ☕️ Reasoning

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beta email access handling to grant all users access by default when no explicit approval list is configured, instead of restricting access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->